### PR TITLE
Update buefy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "collectCoverage": true
   },
   "dependencies": {
-    "buefy": "0.6.6"
+    "buefy": "0.6.7"
   },
   "devDependencies": {
     "codecov": "latest",


### PR DESCRIPTION
My previous PR (https://github.com/buefy/nuxt-buefy/pull/24) isn't completed because it needs to update buefy version.