### PR TITLE
feat: bump Material Design Icons to v2.5.94

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,7 @@ const { resolve } = require('path')
 const defaults = {
     css: true,
     materialDesignIcons: true,
-    materialDesignIconsHRef: '//cdn.materialdesignicons.com/2.4.85/css/materialdesignicons.min.css'
+    materialDesignIconsHRef: '//cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css'
 }
 
 module.exports = async function module(moduleOptions) {


### PR DESCRIPTION
Hi,

I realised that many Material Design Icons were missing.
Updating to the latest version helps a lot. 😉 