### PR TITLE
Set default Material Design Icons HRef to newest CDN  version

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,7 @@ const { resolve } = require('path')
 const defaults = {
     css: true,
     materialDesignIcons: true,
-    materialDesignIconsHRef: '//cdn.materialdesignicons.com/2.4.85/css/materialdesignicons.min.css'
+    materialDesignIconsHRef: '//cdn.materialdesignicons.com/5.0.45/css/materialdesignicons.min.css'
 }
 
 module.exports = async function module(moduleOptions) {


### PR DESCRIPTION
Update default MDI HRef, as some icons are not available in the 2.4.85 version of Material Design Icons, like Github.