### PR TITLE
Update material design icons version

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,7 @@ const { resolve } = require('path')
 const defaults = {
     css: true,
     materialDesignIcons: true,
-    materialDesignIconsHRef: '//cdn.materialdesignicons.com/5.0.45/css/materialdesignicons.min.css'
+    materialDesignIconsHRef: 'https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css'
 }
 
 module.exports = async function module(moduleOptions) {


### PR DESCRIPTION
Considering https://github.com/Templarian/MaterialDesign/issues/5608

I also changed the source to jsdelivr.com