### PR TITLE
Allow use of $buefy in plugins

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -1,4 +1,7 @@
 import Vue from 'vue'
 import Buefy from 'buefy'
 
-Vue.use(Buefy, <%= JSON.stringify(options, null, 2) %>)
+export default (_context, inject) => {
+    Vue.use(Buefy, <%= JSON.stringify(options, null, 2) %>)
+    inject('buefy', Vue.prototype.$buefy)
+}


### PR DESCRIPTION
### Background
I was trying to use the $buefy instance in my own plugin (basically a facade for toasts and snackbars) but I could not access $buefy from my plugin.

eg:
```js
export default ({ app: { $bus, $buefy } }, inject) => {
  console.log('buefy', $buefy) // undefined
  console.log('bus', $bus) // bus object
}
```
This pull request allows you to get the buefy instance from the nuxt context.

eg:
```js
export default ({ $buefy, app: { $bus } }, inject) => {
  console.log('buefy', $buefy) // BUEFY
  console.log('bus', $bus)  // bus object
}
```
