### PR TITLE
Fix: Circle CI Build Failure (#136)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/repo
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.10-browsers
+      - image: cimg/node:18.18-browsers
     steps:
       # Checkout repository
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       # Test
       - run:
           name: Tests
-          command: yarn test
+          command: NODE_OPTIONS=--openssl-legacy-provider yarn test
 
       # Coverage
       - run:


### PR DESCRIPTION
Fixes:
- fixes #136

## Proposed Changes

- Bump the Node version required by CircleCI to the current LTS version v18.18.
- Include `--openssl-legacy-provider` option in `NODE_OPTIONS` environment variable before running test. This will work around the OpenSSL issue of an older Webpack.