### PR TITLE
chore: bump verion to 0.4.27 (Buefy → 0.9.27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "nuxt-buefy",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-buefy",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "MIT",
       "dependencies": {
-        "buefy": "^0.9.25"
+        "buefy": "^0.9.27"
       },
       "devDependencies": {
         "codecov": "^3.1.0",
@@ -7424,9 +7424,9 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.9.25",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.25.tgz",
-      "integrity": "sha512-XOALwf3XzMnJCYslWUALyNZPnloBIsh4X7UYi1DNw7+wDT0uJ6PVDlFUjIKGTLeL0uTC0/O3E+TT60bUj0jGbg==",
+      "version": "0.9.27",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.27.tgz",
+      "integrity": "sha512-1ppk5D5Scb6/vl25nTZVpTFN8UE9ylDjM5dM8zVvvmJhLIOFfx9a7v8aJrzrt/g/48PvucJs/JbhpVMu/1dzjg==",
       "dependencies": {
         "bulma": "0.9.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-buefy",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Nuxt buefy",
   "license": "MIT",
   "contributors": [
@@ -30,7 +30,7 @@
     "collectCoverage": true
   },
   "dependencies": {
-    "buefy": "^0.9.25"
+    "buefy": "^0.9.27"
   },
   "devDependencies": {
     "codecov": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,6 +2994,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bluebird@^3.1.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
@@ -3164,10 +3171,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buefy@^0.9.25:
-  version "0.9.25"
-  resolved "https://registry.npmjs.org/buefy/-/buefy-0.9.25.tgz"
-  integrity sha512-XOALwf3XzMnJCYslWUALyNZPnloBIsh4X7UYi1DNw7+wDT0uJ6PVDlFUjIKGTLeL0uTC0/O3E+TT60bUj0jGbg==
+buefy@^0.9.27:
+  version "0.9.27"
+  resolved "https://registry.npmjs.org/buefy/-/buefy-0.9.27.tgz"
+  integrity sha512-1ppk5D5Scb6/vl25nTZVpTFN8UE9ylDjM5dM8zVvvmJhLIOFfx9a7v8aJrzrt/g/48PvucJs/JbhpVMu/1dzjg==
   dependencies:
     bulma "0.9.4"
 
@@ -5446,6 +5453,11 @@ file-loader@*, file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz"
@@ -5689,6 +5701,19 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^1.2.7:
+  version "1.2.13"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.12.1"
+
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -8095,6 +8120,11 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nan@^2.12.1:
+  version "2.16.0"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
+  integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
 nanoid@^3.1.23, nanoid@^3.3.6:
   version "3.3.6"


### PR DESCRIPTION
## Proposed changes

- Bump version to 0.4.27
- Bump Buefy to 0.9.27