### PR TITLE
chore: bump Buefy to 0.9.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "nuxt-buefy",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-buefy",
-      "version": "0.4.28",
+      "version": "0.4.29",
       "license": "MIT",
       "dependencies": {
-        "buefy": "^0.9.28"
+        "buefy": "^0.9.29"
       },
       "devDependencies": {
         "buffer": "^6.0.3",
@@ -7489,9 +7489,9 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.9.28",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.28.tgz",
-      "integrity": "sha512-5K3UuZT2v4Gv3OXKrjZjlYNZJISwvzDHYYwNiBVzXY6c2QYxI1BmwQuXjSPqyvH5x7JvY9r38I6MRht5UurRVg==",
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.29.tgz",
+      "integrity": "sha512-iJutB/ezTQcxqcKvKz129DzomMjNRGdy23lJBtoFQBG//2NveTcPkN/VRUF70z2WH3JB/5nmVeoxr8QOPcs42w==",
       "dependencies": {
         "bulma": "0.9.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-buefy",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "Nuxt buefy",
   "license": "MIT",
   "contributors": [
@@ -30,7 +30,7 @@
     "collectCoverage": true
   },
   "dependencies": {
-    "buefy": "^0.9.28"
+    "buefy": "^0.9.29"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,10 +3184,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buefy@^0.9.28:
-  version "0.9.28"
-  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.28.tgz#12a82382292c85337a4154b30882c54bd92810ce"
-  integrity sha512-5K3UuZT2v4Gv3OXKrjZjlYNZJISwvzDHYYwNiBVzXY6c2QYxI1BmwQuXjSPqyvH5x7JvY9r38I6MRht5UurRVg==
+buefy@^0.9.29:
+  version "0.9.29"
+  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.29.tgz#1d1fe57a407ef7cd6e9295679371eee63d21bd0f"
+  integrity sha512-iJutB/ezTQcxqcKvKz129DzomMjNRGdy23lJBtoFQBG//2NveTcPkN/VRUF70z2WH3JB/5nmVeoxr8QOPcs42w==
   dependencies:
     bulma "0.9.4"
 


### PR DESCRIPTION
## Proposed changes

- Bump Buefy to 0.9.29
- Bump the package version to 0.4.29